### PR TITLE
Added Snackbar Service, HTTP Interceptor and component

### DIFF
--- a/src/app/components/snackbar/snackbar.component.html
+++ b/src/app/components/snackbar/snackbar.component.html
@@ -1,0 +1,4 @@
+<mat-icon [ngClass]="data.type === 'success' ? 'success' : 'error'">
+  {{ data.type === "success" ? "check_circle" : "cancel" }}
+</mat-icon>
+<span class="snackbar-message">{{ data.message }}</span>

--- a/src/app/components/snackbar/snackbar.component.scss
+++ b/src/app/components/snackbar/snackbar.component.scss
@@ -1,0 +1,29 @@
+:host {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+}
+
+::ng-deep .mat-mdc-snack-bar-container {
+  background: var(--charcoal);
+}
+
+.snack-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 16px;
+  padding: 12px 16px;
+  border-radius: 8px;
+  color: white;
+  font-weight: 500;
+}
+
+.success {
+  color: var(--emerald);
+}
+
+.error {
+  color: var(--blaze);
+}

--- a/src/app/components/snackbar/snackbar.component.ts
+++ b/src/app/components/snackbar/snackbar.component.ts
@@ -1,0 +1,18 @@
+import { CommonModule } from '@angular/common';
+import { Component, Inject } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+import { MAT_SNACK_BAR_DATA } from '@angular/material/snack-bar';
+
+@Component({
+  selector: 'app-snackbar',
+  standalone: true,
+  imports: [CommonModule, MatIconModule],
+  templateUrl: './snackbar.component.html',
+  styleUrl: './snackbar.component.scss',
+})
+export class SnackbarComponent {
+  constructor(
+    @Inject(MAT_SNACK_BAR_DATA)
+    public data: { message: string; type: 'success' | 'error' }
+  ) {}
+}

--- a/src/app/interceptors/error.interceptor.ts
+++ b/src/app/interceptors/error.interceptor.ts
@@ -1,0 +1,29 @@
+import { Injectable, inject } from '@angular/core';
+import {
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest,
+  HttpErrorResponse,
+} from '@angular/common/http';
+import { Observable, catchError, throwError } from 'rxjs';
+import { SnackbarService } from '../services/snackbar.service';
+
+@Injectable()
+export class errorInterceptor implements HttpInterceptor {
+  private snackbarService = inject(SnackbarService);
+
+  intercept(
+    req: HttpRequest<any>,
+    next: HttpHandler
+  ): Observable<HttpEvent<any>> {
+    return next.handle(req).pipe(
+      catchError((error: HttpErrorResponse) => {
+        const errorMessage =
+          error.error?.message || 'An unexpected error occurred';
+        this.snackbarService.showMessage(errorMessage, 'error');
+        return throwError(() => error);
+      })
+    );
+  }
+}

--- a/src/app/pages/login/login.component.ts
+++ b/src/app/pages/login/login.component.ts
@@ -7,6 +7,7 @@ import {
 } from '@angular/forms';
 import { AdminService } from '../../services/admin.service';
 import { Router } from '@angular/router';
+import { SnackbarService } from '../../services/snackbar.service';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ITokenResponse } from '../../interfaces/admin';
 
@@ -20,6 +21,7 @@ import { ITokenResponse } from '../../interfaces/admin';
 export class LoginComponent {
   private adminService = inject(AdminService);
   private router = inject(Router);
+  private snackbarService = inject(SnackbarService);
   private destroyRef = inject(DestroyRef);
 
   form = new FormGroup({
@@ -45,9 +47,14 @@ export class LoginComponent {
       .subscribe({
         next: (response: ITokenResponse) => {
           this.router.navigate(['']);
+          this.snackbarService.showMessage('Login successful!', 'success');
         },
         error: (err) => {
           console.error('Request error:', err.message);
+          this.snackbarService.showMessage(
+            'Incorrect email or password.',
+            'error'
+          );
         },
       });
 

--- a/src/app/services/snackbar.service.ts
+++ b/src/app/services/snackbar.service.ts
@@ -1,0 +1,20 @@
+import { Injectable, inject } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { SnackbarComponent } from '../components/snackbar/snackbar.component';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SnackbarService {
+  private _snackBar = inject(MatSnackBar);
+
+  showMessage(message: string, type: 'success' | 'error' = 'success') {
+    this._snackBar.openFromComponent(SnackbarComponent, {
+      data: { message, type },
+      duration: 5000,
+      horizontalPosition: 'center',
+      verticalPosition: 'bottom',
+      panelClass: [type],
+    });
+  }
+}


### PR DESCRIPTION
### **What was done:**

#### **SnackbarService:**
- Added a service to display messages.
- Supports messages of type "success" and "error".

#### **ErrorInterceptor:**
- Added an HTTP Interceptor to automatically catch errors (e.g., 400, 500) and display them via the Snackbar.

#### **Demo Component:**
- Added a component to test the functionality of the Snackbar and ErrorInterceptor.