### PR TITLE
Add loading state to login flow

### DIFF
--- a/src/app/pages/login/login.component.html
+++ b/src/app/pages/login/login.component.html
@@ -11,8 +11,8 @@
         class="login__input input"
         placeholder="Enter your email"
       />
-      @if (form.get('email')?.invalid && form.get('email')?.touched) {
-      <span class="login__error">Please enter a valid email</span>
+      @if (form.get("email")?.invalid && form.get("email")?.touched) {
+        <span class="login__error">Please enter a valid email</span>
       }
     </div>
 
@@ -25,13 +25,23 @@
         class="login__input input"
         placeholder="Enter your password"
       />
-      @if (form.get('password')?.invalid && form.get('password')?.touched) {
-      <span class="login__error"
-        >Password must be at least 6 characters long</span
-      >
+      @if (form.get("password")?.invalid && form.get("password")?.touched) {
+        <span class="login__error"
+          >Password must be at least 6 characters long</span
+        >
       }
     </div>
 
-    <button type="submit" class="login__btn btn">Log in</button>
+    <button
+      type="submit"
+      class="login__btn btn"
+      [disabled]="isLoading || form.invalid"
+    >
+      @if (isLoading) {
+        <span class="login-spinner"></span> Logging in...
+      } @else {
+        Log in
+      }
+    </button>
   </form>
 </div>

--- a/src/app/pages/login/login.component.scss
+++ b/src/app/pages/login/login.component.scss
@@ -49,4 +49,26 @@
   &__input.ng-invalid.ng-touched + &__error {
     display: block;
   }
+
+  &__btn {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 8px;
+  }
+}
+
+.login-spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.4);
+  border-top-color: #ffffff;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }

--- a/src/app/pages/login/login.component.ts
+++ b/src/app/pages/login/login.component.ts
@@ -10,6 +10,7 @@ import { Router } from '@angular/router';
 import { SnackbarService } from '@services/snackbar.service';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ITokenResponse } from '@interfaces/admin';
+import { finalize } from 'rxjs';
 
 @Component({
   selector: 'app-login',
@@ -23,6 +24,8 @@ export class LoginComponent {
   private router = inject(Router);
   private snackbarService = inject(SnackbarService);
   private destroyRef = inject(DestroyRef);
+
+  public isLoading = false;
 
   form = new FormGroup({
     email: new FormControl(null, [Validators.required, Validators.email]),
@@ -38,12 +41,19 @@ export class LoginComponent {
       return;
     }
 
+    this.isLoading = true;
+
     const subscription = this.adminService
       .login({
         email: this.form.value.email!,
         password: this.form.value.password!,
       })
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => {
+          this.isLoading = false;
+        }),
+      )
       .subscribe({
         next: (response: ITokenResponse) => {
           this.router.navigate(['']);


### PR DESCRIPTION
## What’s done
- added `isLoading` state to LoginComponent
- disabled submit button during request
- added spinner inside login button
- handled request finalize to reset loading state

## Why
Render free tier may cause cold start delays (~30–60s), which made it look like the login button was not working.

This change improves UX by:
- providing visual feedback during request
- preventing multiple submissions

## How to test
- trigger backend restart (Render → Manual Deploy / Restart)
- try to login while backend is starting
- verify:
  - button is disabled
  - spinner is visible
  - button becomes active again after response/error

## UI
Button now shows loading spinner instead of static text during request